### PR TITLE
Added a checkbox to disable the enemy randomization

### DIFF
--- a/RandomizerCommon/ArchipelagoForm.Designer.cs
+++ b/RandomizerCommon/ArchipelagoForm.Designer.cs
@@ -34,6 +34,8 @@
             status = new System.Windows.Forms.Label();
             name = new System.Windows.Forms.TextBox();
             password = new System.Windows.Forms.TextBox();
+            disableEnemyRandomizerLabel = new System.Windows.Forms.Label();
+            disableEnemyRandomizerCheckbox = new System.Windows.Forms.CheckBox();
             SuspendLayout();
             // 
             // url
@@ -90,6 +92,22 @@
             password.PlaceholderText = "Password";
             password.Size = new System.Drawing.Size(637, 44);
             password.TabIndex = 3;
+            //
+            // enemyRandomizerLabel
+            //
+            disableEnemyRandomizerLabel.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
+            disableEnemyRandomizerLabel.Location = new System.Drawing.Point(21, 219);
+            disableEnemyRandomizerLabel.Margin = new System.Windows.Forms.Padding(5);
+            disableEnemyRandomizerLabel.Name = "enemyRandomizerLabel";
+            disableEnemyRandomizerLabel.Size = new System.Drawing.Size(637, 44);
+            disableEnemyRandomizerLabel.Text = "Disable Enemy Randomizer";
+            //
+            // enemyRandomizerCheckbox
+            //
+            disableEnemyRandomizerCheckbox.Location = new System.Drawing.Point(420, 219+3);
+            disableEnemyRandomizerCheckbox.Margin = new System.Windows.Forms.Padding(5);
+            disableEnemyRandomizerCheckbox.Name = "enemyRandomizerCheckbox";
+            disableEnemyRandomizerCheckbox.Size = new System.Drawing.Size(40, 40);
             // 
             // ArchipelagoForm
             // 
@@ -97,6 +115,8 @@
             AutoScaleDimensions = new System.Drawing.SizeF(13F, 32F);
             AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             ClientSize = new System.Drawing.Size(672, 337);
+            Controls.Add(disableEnemyRandomizerCheckbox);
+            Controls.Add(disableEnemyRandomizerLabel);
             Controls.Add(password);
             Controls.Add(name);
             Controls.Add(status);
@@ -117,5 +137,7 @@
         private System.Windows.Forms.Label status;
         private System.Windows.Forms.TextBox name;
         private System.Windows.Forms.TextBox password;
+        private System.Windows.Forms.Label disableEnemyRandomizerLabel;
+        private System.Windows.Forms.CheckBox disableEnemyRandomizerCheckbox;
     }
 }

--- a/RandomizerCommon/ArchipelagoForm.cs
+++ b/RandomizerCommon/ArchipelagoForm.cs
@@ -126,6 +126,10 @@ namespace RandomizerCommon
                 .ToDictionary(entry => long.Parse(entry.Key), entry => entry.Value);
             CheckVersionRange(slotData);
             var options = ((JObject)slotData["options"]).ToObject<Dictionary<string, bool>>();
+            if (disableEnemyRandomizerCheckbox.Checked) {
+                options["randomize_enemies"] = false;
+            }
+
             var opt = ConvertRandomizerOptions(options);
             var itemCounts = ((JObject)slotData["itemCounts"]).ToObject<Dictionary<string, uint>>()
                 .ToDictionary(entry => long.Parse(entry.Key), entry => entry.Value);


### PR DESCRIPTION
As discussed in the discord, this adds a simple checkbox to the UI that when checked disables the enemy randomization.
It does this by simply forcing the received option "randomize_enemies" to false if the checkbox is checked. This has been only tested for a single instance of DarkSouls3 in the Community Async "Hardest Async 2". I do not own Darksouls3 so I can not test this extensively myself.