### PR TITLE
Correct Scrap Magnetite enemy drop in Ashina Castle

### DIFF
--- a/dists/Base/annotations.txt
+++ b/dists/Base/annotations.txt
@@ -404,7 +404,7 @@ Areas:
   Text: Ashina Castle Gate
   Req: ashinaoutskirts_fortress2
   Until: invasion1
-  Archipelago: AC
+  Archipelago: AO
 - Name: ashinacastle
   Text: Ashina Castle
   Req: ashinacastle_gate AND blazingbull

--- a/dists/Base/annotations.txt
+++ b/dists/Base/annotations.txt
@@ -2560,9 +2560,10 @@ Slots:
 - Key: '02,0:51110972::'
   DebugText:
   - 'Scrap Magnetite - 11801000[Taro Troop (c1180_0002 #1110432) ashinacastle, Taro Troop (c1180_0003 #1110433) ashinacastle]'
-  Text: Guaranteed drop from either of the Taro Troop in the courtyard with the tall grass
-  Area: ashinacastle_gate
+  Text: Guaranteed drop from the Taro Troop outside of the building with the Abandoned Dungeon entrance
+  Area: ashinacastle
   Tags: enemy
+  Until: invasion2
 - Key: '02,0:51110973::'
   DebugText:
   - "Ungo's Spiritfall - 13400000[Underwater Headless (c1340_0000 #1110660) ashinacastle]"


### PR DESCRIPTION
Fix Scrap Magnetite enemy drop location referencing the wrong Taro Troop.
This actually drops from the Taro Troop at abandoned dungeon entrance, which is 2 entities depending on invasion state. 
It is unreachable in invasion2, so I added the until part too for future reference.